### PR TITLE
launch-ec2: handle the arch field in image-status' output

### DIFF
--- a/scripts/launch-ec2
+++ b/scripts/launch-ec2
@@ -244,7 +244,7 @@ def get_ec2_image_id(series_name, region_name, root_store_name='ssd',
               ' git clone https://github.com/smoser/talk-simplestreams.git')
         sys.exit(1)
     for line in output.splitlines():
-        series, version, region, root_store, virt, ami_id = line.split()
+        series, arch, version, region, root_store, virt, ami_id = line.split()
         if (series == series_name and region == region_name and
             root_store == root_store_name and virt == virt_type):
             return ami_id


### PR DESCRIPTION
talk-simplestreams commit 94ee064d introduced an architecture field in
the output of image-status. This change makes launch-ec2 compatible with
the new output.