### PR TITLE
lxc-proposed-snapshot: return full path to commands in find_command

### DIFF
--- a/scripts/lxc-proposed-snapshot
+++ b/scripts/lxc-proposed-snapshot
@@ -52,7 +52,7 @@ debug() {
 
 find_command() {
     local cmd="$1" mydir="${0%/*}" fpath=""
-    command -v "$cmd" >/dev/null 2>&1 && _RET="$cmd" && return 0
+    command -v "$cmd" >/dev/null 2>&1 && _RET="$(command -v $cmd)" && return 0
     [ -x "$mydir/$cmd" ] && _RET="$mydir/$cmd" && return 0
     fpath=$(readlink -f "$0")
     mydir="${fpath%/*}"


### PR DESCRIPTION
find_command() is used to determine the path to a command, which is then
used to push that command in to the lxd container being produced.
Currently, if the command is on the user's PATH, instead of returning
the full path, it will return just the name of the command.  As such,
this only works if you're already in the directory containing the
command.

This changes find_command to instead return the full path, fixing
lxc-proposed-snapshot invocation when you have update-root on your PATH.