### PR TITLE
lxc-proposed-snapshot: don't hardcode publication to local "remote"

### DIFF
--- a/scripts/lxc-proposed-snapshot
+++ b/scripts/lxc-proposed-snapshot
@@ -132,7 +132,7 @@ main() {
 
     if [ "$publish" = "true" ]; then
         debug 1 "publishing $cname to alias $pubname"
-        lxc publish "$cname" local: "--alias=$pubname"
+        lxc publish "$cname" "--alias=$pubname"
     else
         CONTAINER_NAME=""
     fi


### PR DESCRIPTION
Use the default remote configured by the user, as that is almost
certainly where they will want to use the generated image (and where the
script will already be building the image).