### PR TITLE
lxc-pstart: make psuedo-init set PATH to fix centos7 container.

### DIFF
--- a/scripts/psuedo-init
+++ b/scripts/psuedo-init
@@ -4,6 +4,7 @@ set -f
 VERBOSITY=1
 LOG="/tmp/${0##*/}.log"
 BK_SUF=".psi-bk"
+PATH=/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 error() { echo "$@" 1>&2; }
 errorrc() { local r=$?; echo "$@" 1>&2; return $r; }


### PR DESCRIPTION
In a centos 7 container psuedo-init would not find the 'ip' command
which is in /usr/sbin.  The easiest thing to do is just to set a
sane path explicitly here.

End result is that 'lxc-pstart --start centos7' works as expected.