### PR TITLE
lxc-pstart: push psuedo-init with uid=0 gid=0

### DIFF
--- a/scripts/lxc-pstart
+++ b/scripts/lxc-pstart
@@ -236,7 +236,7 @@ def do_start(remote, name, prof_name, ctn_cfg, cmd=None):
 
     LOG.debug("Pushing %s to %s/%s",
               pi_host_path, rcontainer, PSUEDO_INIT_PATH)
-    lxc(['file', 'push', '--mode=0755', '-',
+    lxc(['file', 'push', '--mode=0755', '--uid=0', '--gid=0', '-',
          rcontainer + PSUEDO_INIT_PATH],
         data=init_blob,
         fmsg=("Failed to push psuedo-init to %s%s" %


### PR DESCRIPTION
When pushing psuedo-init into the container, explicitly set the
uid and gid to 0.  Without this, at least in lxc 3.18, the file gets
owned by the *outside* uid (for me 1000:1000).

This then has confusing/not-understood adverse effects on the container.
I had seen the 'mount' fail, but have also seen issues wtih dns
functioning.

Regardless, it makes more sense to be explicit here.  init should
be owned by root:root and owned by root.