### PR TITLE
psuedo-init: close file handle on shutdown.

### DIFF
--- a/scripts/psuedo-init
+++ b/scripts/psuedo-init
@@ -41,6 +41,7 @@ cleanup() {
         mv "$f${BK_SUF}" "$f"
     done
     [ ! -f "$FIFO" ] || rm -f "$FIFO"
+    exec 3<&-
     [ ! -f "$0" ] || rm -f "$0"
     for um in $UMOUNTS; do
         umount $um
@@ -168,7 +169,7 @@ main() {
     done
 
     FIFO="/tmp/.init-fifo" IFACE="eth0" RESTORES="" UMOUNTS=""
-    trap "exit 0" QUIT PWR;
+    trap "debug 1 shutting down; exit 0" QUIT PWR;
     trap cleanup EXIT
 
     debug 1 "$0 up got $argn args: $args"


### PR DESCRIPTION
On "happy path" exit, psuedo-init would try to unmount /tmp, but that
would fail because of the open filehandle for the fifo.  The result
would be a message to stderr about umount failing.

This just closes the filehandle before attempting to umount.

So now in the happy path, we have:

$ cat /var/snap/lxd/common/lxd/logs/test-d1/console.log
/sbin/psuedo-init up got 1 args: --network=10.3.23.1/24
mounted /tmp
using 10.3.23.121 from 79
ip addr add 10.3.23.121/24 dev eth0
ip link set eth0 up
ip route add default via "10.3.23.1"
add nameserver 10.3.23.1 to /etc/resolv.conf
shutting down